### PR TITLE
TBD Set default value of `loading` to true

### DIFF
--- a/src/lib/context.js
+++ b/src/lib/context.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const defaultState = {
-  isLoading: false,
+  isLoading: true,
   userInfo: null,
   error: null,
   refreshAuth: () => true


### PR DESCRIPTION
**TBD**

Initial value of `isLoading` is `false` and `userInfo` is `null`, what is obviously inconsistent. That values are passed to Consumer's children and can lead to wrong behavior, as described in https://github.com/hasura/react-check-auth/issues/17, for example. 

I suggest to set initial `isLoading` value to `true`, so components can rely on both `isLoading` and `userInfo`, especially right after rendering.